### PR TITLE
Pricing intelligence v1 (shadow mode)

### DIFF
--- a/.github/workflows/validate-pricing-intelligence.yml
+++ b/.github/workflows/validate-pricing-intelligence.yml
@@ -1,0 +1,50 @@
+name: Validate pricing intelligence
+
+on:
+  pull_request:
+    paths:
+      - "services/pricing-intelligence/**"
+      - "config/intelligence/**"
+      - "infra/pricing-intelligence.bicep"
+      - "scripts/package-pricing-intelligence.mjs"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - ".github/workflows/validate-pricing-intelligence.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  NODE_VERSION: 24
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 11.9.0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+      - run: pnpm install --no-frozen-lockfile
+      - name: Unit tests
+        run: pnpm test:pricing-intelligence
+      - name: Validate Python ETL syntax
+        run: python -m py_compile services/pricing-intelligence/scripts/build_inside_airbnb_snapshot.py
+      - name: Validate JavaScript syntax
+        run: |
+          node --check services/pricing-intelligence/src/ical.js
+          node --check services/pricing-intelligence/src/availability.js
+          node --check services/pricing-intelligence/src/airbnb-earnings.js
+          node --check services/pricing-intelligence/src/inside-airbnb.js
+          node --check services/pricing-intelligence/src/shadow-pricing.js
+          node --check services/pricing-intelligence/src/fx.js
+          node --check services/pricing-intelligence/src/storage.js
+          node --check services/pricing-intelligence/src/functions/daily-refresh.js
+      - name: Package service
+        run: pnpm package:pricing-intelligence

--- a/.github/workflows/validate-pricing-intelligence.yml
+++ b/.github/workflows/validate-pricing-intelligence.yml
@@ -44,6 +44,7 @@ jobs:
           node --check services/pricing-intelligence/src/inside-airbnb.js
           node --check services/pricing-intelligence/src/shadow-pricing.js
           node --check services/pricing-intelligence/src/fx.js
+          node --check services/pricing-intelligence/src/secrets.js
           node --check services/pricing-intelligence/src/storage.js
           node --check services/pricing-intelligence/src/functions/daily-refresh.js
       - name: Package service

--- a/.github/workflows/validate-pricing-intelligence.yml
+++ b/.github/workflows/validate-pricing-intelligence.yml
@@ -43,6 +43,7 @@ jobs:
           node --check services/pricing-intelligence/src/airbnb-earnings.js
           node --check services/pricing-intelligence/src/inside-airbnb.js
           node --check services/pricing-intelligence/src/shadow-pricing.js
+          node --check services/pricing-intelligence/src/intelligence-snapshot.js
           node --check services/pricing-intelligence/src/fx.js
           node --check services/pricing-intelligence/src/secrets.js
           node --check services/pricing-intelligence/src/storage.js

--- a/config/intelligence/casa-de-pedra.json
+++ b/config/intelligence/casa-de-pedra.json
@@ -1,0 +1,68 @@
+{
+  "schema": "pmc.pricing-intelligence-config/v1",
+  "listing": {
+    "name": "Casa de Pedra",
+    "airbnbListingId": "1557623945127773122",
+    "airbnbHostId": "729631893",
+    "timezone": "America/Sao_Paulo",
+    "pricingCurrency": "USD",
+    "marketCurrency": "BRL",
+    "bedrooms": 4,
+    "bathrooms": 4.5,
+    "accommodates": 10
+  },
+  "collection": {
+    "calendarRefresh": "daily",
+    "airbnbCalendarSecret": "airbnb-ical-url",
+    "vrboCalendarSecret": "vrbo-ical-url",
+    "insideAirbnbRawContainer": "pricing-intelligence-raw",
+    "derivedContainer": "pricing-intelligence",
+    "retainSanitizedHistoryIndefinitely": true
+  },
+  "market": {
+    "neighborhoodWeights": {
+      "Copacabana": "1.00",
+      "Ipanema": "0.85",
+      "Leblon": "0.75"
+    },
+    "comparable": {
+      "roomType": "Entire home/apt",
+      "minimumBedrooms": 3,
+      "maximumBedrooms": 5,
+      "minimumAccommodates": 8,
+      "maximumAccommodates": 12,
+      "minimumBathrooms": 2.5
+    }
+  },
+  "airbnbPerformance": {
+    "capturedAt": "2026-08-23",
+    "reportedWindow": "last_month",
+    "windowInterpretation": "Airbnb dashboard preset; treated as approximately one month, not assigned invented exact start/end dates",
+    "bookingConversionPercent": "0.23",
+    "firstPageSearchImpressionRatePercent": "59.7",
+    "searchToListingConversionPercent": "21.41",
+    "listingToBookingConversionPercent": "1.07",
+    "occupancyRatePercent": "34.5",
+    "averageNightsBooked": 10,
+    "averageNightsBlocked": 0,
+    "averageUnbookedNights": 19,
+    "averageCheckIns": 2,
+    "qualityAccuracyPercent": "100"
+  },
+  "history": {
+    "directBookings": 0,
+    "bookingComBookings": 0,
+    "ownerOrFamilyBlocks": 0,
+    "offlineBookings": 0,
+    "manualMaintenanceBlocks": 0,
+    "vrboReservationsLast6Months": 4,
+    "vrboCancellationsLast6Months": 2
+  },
+  "shadowPricing": {
+    "enabled": true,
+    "publishingEnabled": false,
+    "roundingIncrementUsd": "5.00",
+    "maximumShadowIncreasePercent": "35",
+    "maximumShadowDecreasePercent": "25"
+  }
+}

--- a/docs/pricing-intelligence-google-setup.md
+++ b/docs/pricing-intelligence-google-setup.md
@@ -1,0 +1,35 @@
+# Google Search Console and GA4 setup for pricing intelligence
+
+Casa de Pedra currently has neither Google Search Console nor GA4 configured for the pricing-intelligence workflow.
+
+## Search Console
+
+Create a Domain property for `casadepedra.rio` in Google Search Console and verify it with the DNS method. The future collector should request daily query/page/country/device performance and store only aggregate search-intent data needed for pricing analysis.
+
+Recommended retained fields:
+
+- date
+- query
+- page
+- country
+- device
+- impressions
+- clicks
+- ctr
+- average position
+
+The collector must not treat Search Console impressions as bookings or availability.
+
+## Google Analytics 4
+
+Create a GA4 property for Casa de Pedra and a Web data stream for `https://casadepedra.rio`. Initially GA4 is useful for traffic/source/landing-page trends even before direct-booking search telemetry is enabled.
+
+Direct booking-search events are intentionally deferred until a later change. Do not add `stay_search`, `quote_created`, or checkout events in this branch.
+
+## Future secret/config boundary
+
+When the properties exist, keep OAuth/service-account credentials outside Git. Prefer Azure Key Vault or workload identity. Store only property IDs / measurement IDs in non-secret configuration.
+
+## Current status
+
+This repository change does not create the Google account properties because doing so requires authenticated administrative access to the owner's Google account. It prepares the data contract and preserves a clear insertion point for future collectors.

--- a/infra/pricing-intelligence.bicep
+++ b/infra/pricing-intelligence.bicep
@@ -1,0 +1,76 @@
+targetScope = 'resourceGroup'
+
+@description('Existing pricing storage account name.')
+param storageAccountName string
+@description('Existing Flex Consumption App Service Plan resource ID.')
+param appServicePlanId string
+@description('Existing Application Insights component name.')
+param applicationInsightsName string
+@description('Existing user-assigned managed identity resource ID.')
+param identityId string
+@description('Client ID of the managed identity.')
+param identityClientId string
+@description('Existing Key Vault containing private calendar URL secrets.')
+param keyVaultName string
+param location string = resourceGroup().location
+param serviceName string = 'func-cdp-pricing-intelligence'
+param tags object = {}
+
+resource storage 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
+  name: storageAccountName
+}
+
+resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2023-05-01' existing = {
+  parent: storage
+  name: 'default'
+}
+
+resource deploymentContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' = {
+  parent: blobService
+  name: 'app-package-pricing-intelligence'
+}
+
+resource intelligenceContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' = {
+  parent: blobService
+  name: 'pricing-intelligence'
+  properties: { publicAccess: 'None' }
+}
+
+resource rawContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' = {
+  parent: blobService
+  name: 'pricing-intelligence-raw'
+  properties: { publicAccess: 'None' }
+}
+
+module intelligence './app/api.bicep' = {
+  name: 'pricing-intelligence-function'
+  dependsOn: [deploymentContainer, intelligenceContainer, rawContainer]
+  params: {
+    name: serviceName
+    serviceName: 'pricing-intelligence'
+    location: location
+    tags: tags
+    applicationInsightsName: applicationInsightsName
+    appServicePlanId: appServicePlanId
+    runtimeName: 'node'
+    runtimeVersion: '24'
+    storageAccountName: storageAccountName
+    deploymentStorageContainerName: deploymentContainer.name
+    identityId: identityId
+    identityClientId: identityClientId
+    enableBlob: true
+    appSettings: {
+      AZURE_CLIENT_ID: identityClientId
+      PRICING_STORAGE_ACCOUNT_URL: 'https://${storageAccountName}.blob.${environment().suffixes.storage}'
+      INTELLIGENCE_CONTAINER: intelligenceContainer.name
+      INTELLIGENCE_RAW_CONTAINER: rawContainer.name
+      AIRBNB_ICAL_URL: '@Microsoft.KeyVault(VaultName=${keyVaultName};SecretName=airbnb-ical-url)'
+      VRBO_ICAL_URL: '@Microsoft.KeyVault(VaultName=${keyVaultName};SecretName=vrbo-ical-url)'
+      AVAILABILITY_HORIZON_DAYS: '550'
+    }
+  }
+}
+
+output functionAppName string = intelligence.outputs.SERVICE_API_NAME
+output intelligenceContainerName string = intelligenceContainer.name
+output rawContainerName string = rawContainer.name

--- a/infra/pricing-intelligence.bicep
+++ b/infra/pricing-intelligence.bicep
@@ -64,8 +64,9 @@ module intelligence './app/api.bicep' = {
       PRICING_STORAGE_ACCOUNT_URL: 'https://${storageAccountName}.blob.${environment().suffixes.storage}'
       INTELLIGENCE_CONTAINER: intelligenceContainer.name
       INTELLIGENCE_RAW_CONTAINER: rawContainer.name
-      AIRBNB_ICAL_URL: '@Microsoft.KeyVault(VaultName=${keyVaultName};SecretName=airbnb-ical-url)'
-      VRBO_ICAL_URL: '@Microsoft.KeyVault(VaultName=${keyVaultName};SecretName=vrbo-ical-url)'
+      KEY_VAULT_URL: 'https://${keyVaultName}.vault.azure.net'
+      AIRBNB_ICAL_SECRET_NAME: 'airbnb-ical-url'
+      VRBO_ICAL_SECRET_NAME: 'vrbo-ical-url'
       AVAILABILITY_HORIZON_DAYS: '550'
     }
   }

--- a/package.json
+++ b/package.json
@@ -11,9 +11,11 @@
     "build": "node scripts/build-static.mjs",
     "build:static": "node scripts/build-static.mjs",
     "package:pricing-api": "node scripts/package-pricing-api.mjs",
+    "package:pricing-intelligence": "node scripts/package-pricing-intelligence.mjs",
     "test": "pnpm --recursive test",
     "test:engine": "pnpm --filter @pmc/price-engine test",
     "test:pricing-spa": "pnpm --filter @pmc/pricing-calendar-spa test",
-    "test:pricing-api": "pnpm --filter @pmc/pricing-api test"
+    "test:pricing-api": "pnpm --filter @pmc/pricing-api test",
+    "test:pricing-intelligence": "pnpm --filter @pmc/pricing-intelligence test"
   }
 }

--- a/scripts/package-pricing-intelligence.mjs
+++ b/scripts/package-pricing-intelligence.mjs
@@ -1,10 +1,16 @@
+import { execFile } from "node:child_process";
 import { cp, mkdir, rm } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
 
+const execFileAsync = promisify(execFile);
 const repositoryRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const serviceRoot = join(repositoryRoot, "services", "pricing-intelligence");
 const outputRoot = join(repositoryRoot, ".deploy", "pricing-intelligence");
+const pnpmCli = process.env.npm_execpath;
+
+if (!pnpmCli) throw new Error("Run this script through pnpm so npm_execpath is available.");
 
 await rm(outputRoot, { recursive: true, force: true });
 await mkdir(outputRoot, { recursive: true });
@@ -12,5 +18,14 @@ for (const file of ["host.json", "package.json", ".funcignore"]) {
   await cp(join(serviceRoot, file), join(outputRoot, file));
 }
 await cp(join(serviceRoot, "src"), join(outputRoot, "src"), { recursive: true });
+
+await execFileAsync(process.execPath, [
+  pnpmCli,
+  "install",
+  "--prod",
+  "--ignore-workspace",
+  "--config.node-linker=hoisted",
+  "--config.package-import-method=copy",
+], { cwd: outputRoot });
 
 console.log(`Prepared standalone pricing intelligence package at ${outputRoot}`);

--- a/scripts/package-pricing-intelligence.mjs
+++ b/scripts/package-pricing-intelligence.mjs
@@ -1,0 +1,16 @@
+import { cp, mkdir, rm } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const serviceRoot = join(repositoryRoot, "services", "pricing-intelligence");
+const outputRoot = join(repositoryRoot, ".deploy", "pricing-intelligence");
+
+await rm(outputRoot, { recursive: true, force: true });
+await mkdir(outputRoot, { recursive: true });
+for (const file of ["host.json", "package.json", ".funcignore"]) {
+  await cp(join(serviceRoot, file), join(outputRoot, file));
+}
+await cp(join(serviceRoot, "src"), join(outputRoot, "src"), { recursive: true });
+
+console.log(`Prepared standalone pricing intelligence package at ${outputRoot}`);

--- a/services/pricing-intelligence/.funcignore
+++ b/services/pricing-intelligence/.funcignore
@@ -1,0 +1,3 @@
+test
+README.md
+*.local.json

--- a/services/pricing-intelligence/README.md
+++ b/services/pricing-intelligence/README.md
@@ -1,0 +1,70 @@
+# @pmc/pricing-intelligence
+
+Read-only market intelligence and shadow pricing for Casa de Pedra. This service is intentionally outside `@pmc/price-engine` and outside the authoritative pricing API calculation boundary.
+
+## v1 behavior
+
+- polls the private Airbnb and Vrbo iCalendar feeds once daily
+- strips guest names, phone digits, reservation URLs and provider free text before persistence
+- merges cross-synchronized calendars so mirrored blocks do not double-count the same reservation
+- retains immutable point-in-time availability snapshots for future pickup/cancellation analysis
+- ingests sanitized Airbnb reservation economics separately from payouts/guest identity
+- builds a weighted Inside Airbnb comparable market from Copacabana, Ipanema and Leblon
+- normalizes BRL/USD using Banco Central do Brasil PTAX
+- produces transparent shadow pricing recommendations only
+- never publishes prices or modifies availability
+
+## Neighborhood relevance weights
+
+The base weights are relevance weights, not price discounts:
+
+- Copacabana: `1.00` — direct submarket
+- Ipanema: `0.85` — strong nearby substitute for premium group stays
+- Leblon: `0.75` — relevant premium substitute but a more distinct submarket
+
+Property similarity then further weights bedroom count, capacity, bathrooms and villa/house property type. The initial attached Rio release produced 524 qualifying listings before similarity weighting: 392 Copacabana, 92 Ipanema and 40 Leblon.
+
+## Secrets
+
+Do not commit provider calendar URLs. Production expects Key Vault-backed app settings:
+
+- `AIRBNB_ICAL_URL`
+- `VRBO_ICAL_URL`
+
+The configured secret names are `airbnb-ical-url` and `vrbo-ical-url`.
+
+## Storage
+
+`pricing-intelligence` contains sanitized immutable snapshots and `latest.json` pointers. `pricing-intelligence-raw` is reserved for raw public market releases such as Inside Airbnb. Raw provider calendars are deliberately not persisted because they contain reservation details.
+
+## Inside Airbnb ETL
+
+The Rio calendar is too large to load into the Function on every run. Generate a compact derived snapshot offline:
+
+```bash
+python services/pricing-intelligence/scripts/build_inside_airbnb_snapshot.py \
+  --config config/intelligence/casa-de-pedra.json \
+  --listings listings.csv.gz \
+  --calendar calendar.csv.gz \
+  --output rio-market.json
+```
+
+The derived snapshot explicitly treats unavailable dates as `booked-or-host-blocked`, never as proven occupancy.
+
+## Shadow pricing
+
+The v1 model starts with a price supplied by the authoritative pricing policy and computes a bounded recommendation using inspectable factors such as market compression, market availability, lead time, booking pace, search demand and event demand. Missing signals are simply omitted. Every result contains `mode: "shadow"` and `publish: false`.
+
+This heuristic is a data-collection/champion baseline. It is not the eventual ML model.
+
+## Google data
+
+Search Console and GA4 do not currently exist for the property. Their creation requires access to the owner's Google account and cannot be performed by this repository. Once created, future collectors can add Search Console query/impression data and GA4 traffic data. Direct-site booking-search telemetry is intentionally deferred per the owner decision.
+
+## Validation
+
+```bash
+pnpm test:pricing-intelligence
+```
+
+Production deployment should occur only after the feature branch is reviewed and the Key Vault secrets have been created. The branch must not be interpreted as approval to publish intelligence recommendations to Airbnb, Vrbo or direct booking.

--- a/services/pricing-intelligence/examples/airbnb-history.sanitized.json
+++ b/services/pricing-intelligence/examples/airbnb-history.sanitized.json
@@ -1,0 +1,17 @@
+{
+  "schema": "pmc.sanitized-booking-history/v1",
+  "provider": "airbnb",
+  "source": "owner Airbnb earnings export uploaded 2026-08-23",
+  "privacy": "guest names, confirmation/reference codes, payout destinations and payment details removed",
+  "reservations": [
+    {"bookingDate":"2026-08-01","start":"2026-08-06","endExclusive":"2026-08-11","nights":5,"currency":"BRL","hostAmount":"9214.08","serviceFee":"383.92","cleaningFee":"0.00","grossEarnings":"9598.00","remittedTax":"0.00"},
+    {"bookingDate":"2026-07-29","start":"2026-07-30","endExclusive":"2026-08-04","nights":5,"currency":"BRL","hostAmount":"9213.70","serviceFee":"383.90","cleaningFee":"0.00","grossEarnings":"9597.60","remittedTax":"0.00"},
+    {"bookingDate":"2026-07-17","start":"2026-07-18","endExclusive":"2026-07-21","nights":3,"currency":"BRL","hostAmount":"5270.40","serviceFee":"219.60","cleaningFee":"0.00","grossEarnings":"5490.00","remittedTax":"0.00"},
+    {"bookingDate":"2026-05-19","start":"2026-06-04","endExclusive":"2026-06-07","nights":3,"currency":"BRL","hostAmount":"6240.00","serviceFee":"260.00","cleaningFee":"0.00","grossEarnings":"6500.00","remittedTax":"0.00"},
+    {"bookingDate":"2026-03-18","start":"2026-05-23","endExclusive":"2026-05-26","nights":3,"currency":"BRL","hostAmount":"5385.60","serviceFee":"224.40","cleaningFee":"0.00","grossEarnings":"5610.00","remittedTax":"0.00"},
+    {"bookingDate":"2026-04-19","start":"2026-04-19","endExclusive":"2026-04-23","nights":4,"currency":"BRL","hostAmount":"6201.60","serviceFee":"258.40","cleaningFee":"0.00","grossEarnings":"6460.00","remittedTax":"0.00"},
+    {"bookingDate":"2025-11-27","start":"2026-02-17","endExclusive":"2026-02-20","nights":3,"currency":"BRL","hostAmount":"4896.00","serviceFee":"204.00","cleaningFee":"0.00","grossEarnings":"5100.00","remittedTax":"0.00"},
+    {"bookingDate":"2025-11-20","start":"2026-02-09","endExclusive":"2026-02-17","nights":8,"currency":"BRL","hostAmount":"12631.68","serviceFee":"526.32","cleaningFee":"0.00","grossEarnings":"13158.00","remittedTax":"0.00"}
+  ],
+  "summary": {"reservations":8,"nights":34,"currency":"BRL","hostAmount":"59053.06","serviceFee":"2460.54","grossEarnings":"61513.60"}
+}

--- a/services/pricing-intelligence/examples/inside-airbnb-rio-2026-06-26.summary.json
+++ b/services/pricing-intelligence/examples/inside-airbnb-rio-2026-06-26.summary.json
@@ -1,0 +1,35 @@
+{
+  "schema": "pmc.market-intelligence-bootstrap/v1",
+  "source": "Inside Airbnb Rio de Janeiro release supplied by owner",
+  "comparableSet": {
+    "count": 524,
+    "effectiveSampleSize": 487.18,
+    "countsByNeighborhood": {"Copacabana":392,"Ipanema":92,"Leblon":40},
+    "weightByNeighborhood": {"Copacabana":222.403075,"Ipanema":44.650763,"Leblon":17.901791},
+    "neighborhoodBaseWeights": {"Copacabana":"1.00","Ipanema":"0.85","Leblon":"0.75"}
+  },
+  "monthlyBenchmarks": {
+    "2026-07":{"medianAvailabilityRate":0.5591,"medianCompressionIndex":0.4409,"medianMinimumStay":3},
+    "2026-08":{"medianAvailabilityRate":0.6315,"medianCompressionIndex":0.3685,"medianMinimumStay":3},
+    "2026-09":{"medianAvailabilityRate":0.6285,"medianCompressionIndex":0.3715,"medianMinimumStay":3},
+    "2026-10":{"medianAvailabilityRate":0.6126,"medianCompressionIndex":0.3874,"medianMinimumStay":3},
+    "2026-11":{"medianAvailabilityRate":0.6106,"medianCompressionIndex":0.3894,"medianMinimumStay":3},
+    "2026-12":{"medianAvailabilityRate":0.6185,"medianCompressionIndex":0.3815,"medianMinimumStay":3},
+    "2027-01":{"medianAvailabilityRate":0.5264,"medianCompressionIndex":0.4736,"medianMinimumStay":3},
+    "2027-02":{"medianAvailabilityRate":0.5054,"medianCompressionIndex":0.4946,"medianMinimumStay":3}
+  },
+  "eventSamples": {
+    "2026-12-29":{"weightedAvailabilityRate":0.385263,"marketCompressionIndex":0.614737,"availableComparableCount":204,"marketMedianMinimumStay":5,"marketP75MinimumStay":7},
+    "2026-12-30":{"weightedAvailabilityRate":0.344595,"marketCompressionIndex":0.655405,"availableComparableCount":182,"marketMedianMinimumStay":5,"marketP75MinimumStay":7},
+    "2026-12-31":{"weightedAvailabilityRate":0.338214,"marketCompressionIndex":0.661786,"availableComparableCount":178,"marketMedianMinimumStay":5,"marketP75MinimumStay":7},
+    "2027-01-01":{"weightedAvailabilityRate":0.352104,"marketCompressionIndex":0.647896,"availableComparableCount":185,"marketMedianMinimumStay":5,"marketP75MinimumStay":7},
+    "2027-02-05":{"weightedAvailabilityRate":0.36461,"marketCompressionIndex":0.63539,"availableComparableCount":193,"marketMedianMinimumStay":5,"marketP75MinimumStay":7},
+    "2027-02-06":{"weightedAvailabilityRate":0.346918,"marketCompressionIndex":0.653082,"availableComparableCount":184,"marketMedianMinimumStay":5,"marketP75MinimumStay":7},
+    "2027-02-07":{"weightedAvailabilityRate":0.348978,"marketCompressionIndex":0.651022,"availableComparableCount":186,"marketMedianMinimumStay":5,"marketP75MinimumStay":7},
+    "2027-02-08":{"weightedAvailabilityRate":0.355063,"marketCompressionIndex":0.644937,"availableComparableCount":189,"marketMedianMinimumStay":5,"marketP75MinimumStay":7}
+  },
+  "limitations": [
+    "Inside Airbnb unavailable dates mean booked or host-blocked, not proven occupancy.",
+    "Competitor price percentiles require matched quote dates before they can be used safely."
+  ]
+}

--- a/services/pricing-intelligence/host.json
+++ b/services/pricing-intelligence/host.json
@@ -1,0 +1,15 @@
+{
+  "version": "2.0",
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true,
+        "excludedTypes": "Request"
+      }
+    }
+  },
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  }
+}

--- a/services/pricing-intelligence/package.json
+++ b/services/pricing-intelligence/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@pmc/pricing-intelligence",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Read-only market intelligence, availability ingestion, and shadow pricing recommendations for Casa de Pedra.",
+  "type": "module",
+  "main": "src/functions/*.js",
+  "scripts": {
+    "start": "func start",
+    "test": "node --test test/*.test.js"
+  },
+  "dependencies": {
+    "@azure/functions": "^4.11.0",
+    "@azure/identity": "^4.13.0",
+    "@azure/storage-blob": "^12.30.0"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/services/pricing-intelligence/package.json
+++ b/services/pricing-intelligence/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@azure/functions": "^4.11.0",
     "@azure/identity": "^4.13.0",
+    "@azure/keyvault-secrets": "^4.11.2",
     "@azure/storage-blob": "^12.30.0"
   },
   "engines": {

--- a/services/pricing-intelligence/scripts/build_inside_airbnb_snapshot.py
+++ b/services/pricing-intelligence/scripts/build_inside_airbnb_snapshot.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+import argparse, csv, gzip, hashlib, json, math
+from collections import defaultdict
+from pathlib import Path
+
+
+def num(value):
+    try:
+        return float(value) if value not in (None, "") else None
+    except ValueError:
+        return None
+
+
+def open_csv(path):
+    if str(path).endswith(".gz"):
+        return gzip.open(path, "rt", encoding="utf-8", newline="")
+    return open(path, "r", encoding="utf-8", newline="")
+
+
+def weighted_quantile(items, q):
+    if not items:
+        return None
+    items = sorted(items)
+    total = sum(weight for _, weight in items)
+    threshold = total * q
+    cumulative = 0.0
+    for value, weight in items:
+        cumulative += weight
+        if cumulative >= threshold:
+            return value
+    return items[-1][0]
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", required=True)
+    parser.add_argument("--listings", required=True)
+    parser.add_argument("--calendar", required=True)
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+
+    config = json.loads(Path(args.config).read_text(encoding="utf-8"))
+    market = config["market"]
+    rules = market["comparable"]
+    target = config["listing"]
+    neighborhood_weights = {k: float(v) for k, v in market["neighborhoodWeights"].items()}
+
+    comps = {}
+    counts = defaultdict(int)
+    weight_by_neighborhood = defaultdict(float)
+    scrape_dates = set()
+
+    with open_csv(args.listings) as handle:
+        for row in csv.DictReader(handle):
+            neighborhood = row.get("neighbourhood_cleansed")
+            if neighborhood not in neighborhood_weights:
+                continue
+            if row.get("room_type") != rules["roomType"]:
+                continue
+            bedrooms = num(row.get("bedrooms")); bathrooms = num(row.get("bathrooms")); accommodates = num(row.get("accommodates"))
+            if bedrooms is None or accommodates is None:
+                continue
+            if not (rules["minimumBedrooms"] <= bedrooms <= rules["maximumBedrooms"]):
+                continue
+            if not (rules["minimumAccommodates"] <= accommodates <= rules["maximumAccommodates"]):
+                continue
+            if bathrooms is not None and bathrooms < rules["minimumBathrooms"]:
+                continue
+
+            weight = neighborhood_weights[neighborhood]
+            weight *= math.exp(-0.35 * abs(bedrooms - target["bedrooms"]))
+            weight *= math.exp(-0.14 * abs(accommodates - target["accommodates"]))
+            if bathrooms is not None:
+                weight *= math.exp(-0.18 * abs(bathrooms - target["bathrooms"]))
+            prop = (row.get("property_type") or "").lower()
+            if "villa" in prop:
+                weight *= 1.15
+            elif "house" in prop or "home" in prop:
+                weight *= 1.05
+
+            listing_id = str(row["id"])
+            comps[listing_id] = weight
+            counts[neighborhood] += 1
+            weight_by_neighborhood[neighborhood] += weight
+            if row.get("last_scraped"):
+                scrape_dates.add(row["last_scraped"])
+
+    total_weight = sum(comps.values())
+    sum_squares = sum(w*w for w in comps.values())
+    effective_sample_size = total_weight*total_weight/sum_squares if sum_squares else 0.0
+    comparable_hash = hashlib.sha256("\n".join(f"{k}:{comps[k]:.12f}" for k in sorted(comps)).encode()).hexdigest()
+
+    daily = defaultdict(lambda: {"availableWeight": 0.0, "availableCount": 0, "minStay": []})
+    with open_csv(args.calendar) as handle:
+        for row in csv.DictReader(handle):
+            listing_id = str(row.get("listing_id", ""))
+            weight = comps.get(listing_id)
+            if weight is None:
+                continue
+            date = row.get("date")
+            if not date:
+                continue
+            available = (row.get("available") or "").lower() in ("t", "true", "1")
+            if available:
+                daily[date]["availableWeight"] += weight
+                daily[date]["availableCount"] += 1
+                minimum = num(row.get("minimum_nights"))
+                if minimum is not None:
+                    daily[date]["minStay"].append((minimum, weight))
+
+    dates = {}
+    for date in sorted(daily):
+        bucket = daily[date]
+        availability = bucket["availableWeight"] / total_weight if total_weight else None
+        dates[date] = {
+            "weightedAvailabilityRate": round(availability, 6) if availability is not None else None,
+            "marketCompressionIndex": round(1-availability, 6) if availability is not None else None,
+            "availableComparableCount": bucket["availableCount"],
+            "marketMedianMinimumStay": weighted_quantile(bucket["minStay"], 0.5),
+            "marketP75MinimumStay": weighted_quantile(bucket["minStay"], 0.75),
+            "unavailableMeans": "booked-or-host-blocked"
+        }
+
+    output = {
+        "schema": "pmc.market-intelligence-snapshot/v1",
+        "source": "Inside Airbnb Rio de Janeiro",
+        "sourceScrapeDates": sorted(scrape_dates),
+        "comparableSet": {
+            "count": len(comps),
+            "effectiveSampleSize": round(effective_sample_size, 2),
+            "countsByNeighborhood": dict(sorted(counts.items())),
+            "weightByNeighborhood": {k: round(v, 6) for k, v in sorted(weight_by_neighborhood.items())},
+            "neighborhoodBaseWeights": market["neighborhoodWeights"],
+            "hash": comparable_hash
+        },
+        "limitations": [
+            "Inside Airbnb unavailable dates may be bookings or host blocks; they are not treated as proven occupancy.",
+            "This snapshot does not infer matched-date competitor price percentiles unless quote dates are normalized separately."
+        ],
+        "dates": dates
+    }
+    Path(args.output).write_text(json.dumps(output, indent=2) + "\n", encoding="utf-8")
+
+if __name__ == "__main__":
+    main()

--- a/services/pricing-intelligence/src/airbnb-earnings.js
+++ b/services/pricing-intelligence/src/airbnb-earnings.js
@@ -1,0 +1,60 @@
+import { parseCsv, numberOrNull } from "./csv.js";
+
+function isoDateFromUs(value) {
+  if (!value) return null;
+  const match = /^(\d{2})\/(\d{2})\/(\d{4})$/.exec(value);
+  if (!match) return null;
+  return `${match[3]}-${match[1]}-${match[2]}`;
+}
+
+/**
+ * Convert an Airbnb earnings CSV into a privacy-preserving reservation history.
+ * Guest names, confirmation/reference codes, payout destinations and free-text
+ * details are deliberately discarded.
+ */
+export function sanitizeAirbnbEarningsCsv(text) {
+  const rows = parseCsv(text);
+  const reservations = rows
+    .filter((row) => row.Type === "Reservation")
+    .map((row) => ({
+      bookingDate: isoDateFromUs(row["Booking date"]),
+      start: isoDateFromUs(row["Start date"]),
+      endExclusive: isoDateFromUs(row["End date"]),
+      nights: numberOrNull(row.Nights),
+      currency: row.Currency || null,
+      hostAmount: numberOrNull(row.Amount),
+      serviceFee: numberOrNull(row["Service fee"]),
+      cleaningFee: numberOrNull(row["Cleaning fee"]),
+      grossEarnings: numberOrNull(row["Gross earnings"]),
+      remittedTax: numberOrNull(row["Airbnb remitted tax"]),
+    }));
+
+  const summaryByCurrency = {};
+  for (const reservation of reservations) {
+    const currency = reservation.currency ?? "UNKNOWN";
+    summaryByCurrency[currency] ??= {
+      reservations: 0,
+      nights: 0,
+      hostAmount: 0,
+      serviceFee: 0,
+      cleaningFee: 0,
+      grossEarnings: 0,
+      remittedTax: 0,
+    };
+    const summary = summaryByCurrency[currency];
+    summary.reservations += 1;
+    summary.nights += reservation.nights ?? 0;
+    summary.hostAmount += reservation.hostAmount ?? 0;
+    summary.serviceFee += reservation.serviceFee ?? 0;
+    summary.cleaningFee += reservation.cleaningFee ?? 0;
+    summary.grossEarnings += reservation.grossEarnings ?? 0;
+    summary.remittedTax += reservation.remittedTax ?? 0;
+  }
+
+  return {
+    schema: "pmc.sanitized-booking-history/v1",
+    provider: "airbnb",
+    reservations,
+    summaryByCurrency,
+  };
+}

--- a/services/pricing-intelligence/src/availability.js
+++ b/services/pricing-intelligence/src/availability.js
@@ -1,0 +1,73 @@
+function parseDate(date) {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date ?? "");
+  if (!match) throw new Error(`Invalid date: ${date}`);
+  return Date.UTC(Number(match[1]), Number(match[2]) - 1, Number(match[3]));
+}
+
+function formatDate(ms) {
+  return new Date(ms).toISOString().slice(0, 10);
+}
+
+function dateRange(from, through) {
+  const start = parseDate(from);
+  const end = parseDate(through);
+  if (end < start) throw new Error("through must not be before from");
+  const dates = [];
+  for (let ms = start; ms <= end; ms += 86400000) dates.push(formatDate(ms));
+  return dates;
+}
+
+function eventDates(event) {
+  const start = parseDate(event.start);
+  const endExclusive = parseDate(event.endExclusive);
+  const dates = [];
+  for (let ms = start; ms < endExclusive; ms += 86400000) dates.push(formatDate(ms));
+  return dates;
+}
+
+/**
+ * Merge cross-synchronized provider calendars into a single daily inventory
+ * view. Native provider "reservation" evidence outranks mirrored "blocked"
+ * evidence, preventing the same stay from being counted twice.
+ */
+export function buildAvailabilitySnapshot({ calendars, from, through, asOf }) {
+  const dates = Object.fromEntries(
+    dateRange(from, through).map((date) => [date, {
+      state: "available",
+      sources: [],
+      evidence: [],
+    }]),
+  );
+
+  const orderedEvents = calendars
+    .flatMap((calendar) => calendar.events)
+    .sort((a, b) => Number(a.kind === "blocked") - Number(b.kind === "blocked"));
+
+  for (const event of orderedEvents) {
+    for (const date of eventDates(event)) {
+      const target = dates[date];
+      if (!target) continue;
+      if (event.kind === "reservation") target.state = "reserved";
+      else if (target.state === "available") target.state = "blocked";
+      if (!target.sources.includes(event.source)) target.sources.push(event.source);
+      if (!target.evidence.includes(event.sourceEventHash)) target.evidence.push(event.sourceEventHash);
+    }
+  }
+
+  const counts = { available: 0, reserved: 0, blocked: 0 };
+  for (const value of Object.values(dates)) counts[value.state] += 1;
+
+  return {
+    schema: "pmc.availability-snapshot/v1",
+    asOf,
+    coverage: { from, through },
+    counts,
+    dates,
+  };
+}
+
+export function summarizeReservationIntervals(calendar) {
+  return calendar.events
+    .filter((event) => event.kind === "reservation")
+    .map(({ start, endExclusive, source }) => ({ start, endExclusive, source }));
+}

--- a/services/pricing-intelligence/src/csv.js
+++ b/services/pricing-intelligence/src/csv.js
@@ -1,0 +1,49 @@
+export function parseCsv(text) {
+  const rows = [];
+  let row = [];
+  let field = "";
+  let quoted = false;
+  const input = String(text).replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+
+  for (let i = 0; i < input.length; i += 1) {
+    const ch = input[i];
+    if (quoted) {
+      if (ch === '"' && input[i + 1] === '"') {
+        field += '"';
+        i += 1;
+      } else if (ch === '"') {
+        quoted = false;
+      } else {
+        field += ch;
+      }
+      continue;
+    }
+    if (ch === '"') quoted = true;
+    else if (ch === ",") {
+      row.push(field);
+      field = "";
+    } else if (ch === "\n") {
+      row.push(field);
+      if (row.some((value) => value !== "")) rows.push(row);
+      row = [];
+      field = "";
+    } else field += ch;
+  }
+
+  if (field !== "" || row.length > 0) {
+    row.push(field);
+    if (row.some((value) => value !== "")) rows.push(row);
+  }
+  if (rows.length === 0) return [];
+
+  const headers = rows[0];
+  return rows.slice(1).map((values) => Object.fromEntries(
+    headers.map((header, index) => [header, values[index] ?? ""]),
+  ));
+}
+
+export function numberOrNull(value) {
+  if (value === null || value === undefined || String(value).trim() === "") return null;
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+}

--- a/services/pricing-intelligence/src/functions/daily-refresh.js
+++ b/services/pricing-intelligence/src/functions/daily-refresh.js
@@ -1,0 +1,71 @@
+import { app } from "@azure/functions";
+import { parseProviderCalendar } from "../ical.js";
+import { buildAvailabilitySnapshot } from "../availability.js";
+import { writeImmutableJson, writeLatestJson } from "../storage.js";
+
+function addDays(date, days) {
+  const ms = Date.parse(`${date}T00:00:00Z`) + days * 86400000;
+  return new Date(ms).toISOString().slice(0, 10);
+}
+
+async function fetchText(url, provider) {
+  if (!url) throw new Error(`${provider} calendar URL is not configured`);
+  const response = await fetch(url, {
+    headers: { "user-agent": "CasaDePedra-PricingIntelligence/1.0" },
+    signal: AbortSignal.timeout(20000),
+  });
+  if (!response.ok) throw new Error(`${provider} calendar request failed: ${response.status}`);
+  return response.text();
+}
+
+export async function refreshAvailability(context = console) {
+  const asOf = new Date().toISOString();
+  const today = asOf.slice(0, 10);
+  const through = addDays(today, Number(process.env.AVAILABILITY_HORIZON_DAYS ?? 550));
+
+  const [airbnbText, vrboText] = await Promise.all([
+    fetchText(process.env.AIRBNB_ICAL_URL, "Airbnb"),
+    fetchText(process.env.VRBO_ICAL_URL, "Vrbo"),
+  ]);
+
+  const calendars = [
+    parseProviderCalendar(airbnbText, { source: "airbnb" }),
+    parseProviderCalendar(vrboText, { source: "vrbo" }),
+  ];
+
+  const snapshot = buildAvailabilitySnapshot({
+    calendars,
+    from: today,
+    through,
+    asOf,
+  });
+  snapshot.id = `casa-availability-${asOf.replace(/[:.]/g, "-")}`;
+  snapshot.sourceSummary = Object.fromEntries(calendars.map((calendar) => [
+    calendar.source,
+    {
+      reservationIntervals: calendar.events.filter((event) => event.kind === "reservation").length,
+      blockedIntervals: calendar.events.filter((event) => event.kind === "blocked").length,
+    },
+  ]));
+  snapshot.privacy = {
+    rawCalendarPersisted: false,
+    guestNamesPersisted: false,
+    phoneDigitsPersisted: false,
+    reservationUrlsPersisted: false,
+  };
+
+  const accountUrl = process.env.PRICING_STORAGE_ACCOUNT_URL;
+  const container = process.env.INTELLIGENCE_CONTAINER ?? "pricing-intelligence";
+  const safeStamp = asOf.replace(/[:.]/g, "-");
+  const datedName = `availability/${today.slice(0, 4)}/${today.slice(5, 7)}/${today.slice(8, 10)}/${safeStamp}.json`;
+  await writeImmutableJson({ accountUrl, container, blobName: datedName, value: snapshot });
+  await writeLatestJson({ accountUrl, container, blobName: "availability/latest.json", value: snapshot });
+  context.log?.(`Wrote sanitized availability snapshot ${snapshot.id}`);
+  return snapshot;
+}
+
+app.timer("pricing-intelligence-daily-refresh", {
+  schedule: "0 15 9 * * *",
+  runOnStartup: false,
+  handler: async (_timer, context) => refreshAvailability(context),
+});

--- a/services/pricing-intelligence/src/functions/daily-refresh.js
+++ b/services/pricing-intelligence/src/functions/daily-refresh.js
@@ -1,6 +1,7 @@
 import { app } from "@azure/functions";
 import { parseProviderCalendar } from "../ical.js";
 import { buildAvailabilitySnapshot } from "../availability.js";
+import { getProviderCalendarUrls } from "../secrets.js";
 import { writeImmutableJson, writeLatestJson } from "../storage.js";
 
 function addDays(date, days) {
@@ -22,10 +23,11 @@ export async function refreshAvailability(context = console) {
   const asOf = new Date().toISOString();
   const today = asOf.slice(0, 10);
   const through = addDays(today, Number(process.env.AVAILABILITY_HORIZON_DAYS ?? 550));
+  const urls = await getProviderCalendarUrls();
 
   const [airbnbText, vrboText] = await Promise.all([
-    fetchText(process.env.AIRBNB_ICAL_URL, "Airbnb"),
-    fetchText(process.env.VRBO_ICAL_URL, "Vrbo"),
+    fetchText(urls.airbnb, "Airbnb"),
+    fetchText(urls.vrbo, "Vrbo"),
   ]);
 
   const calendars = [

--- a/services/pricing-intelligence/src/fx.js
+++ b/services/pricing-intelligence/src/fx.js
@@ -1,0 +1,47 @@
+function formatPtaxDate(date) {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date ?? "");
+  if (!match) throw new Error(`Invalid ISO date: ${date}`);
+  return `${match[2]}-${match[3]}-${match[1]}`;
+}
+
+function subtractDays(date, days) {
+  const ms = Date.parse(`${date}T00:00:00Z`) - days * 86400000;
+  return new Date(ms).toISOString().slice(0, 10);
+}
+
+export async function fetchPtaxUsdBrl(date, { fetchImpl = fetch, maxLookbackDays = 7 } = {}) {
+  for (let offset = 0; offset <= maxLookbackDays; offset += 1) {
+    const observedDate = subtractDays(date, offset);
+    const ptaxDate = formatPtaxDate(observedDate);
+    const endpoint = new URL("https://olinda.bcb.gov.br/olinda/servico/PTAX/versao/v1/odata/CotacaoMoedaDia(moeda=@moeda,dataCotacao=@dataCotacao)");
+    endpoint.searchParams.set("@moeda", "'USD'");
+    endpoint.searchParams.set("@dataCotacao", `'${ptaxDate}'`);
+    endpoint.searchParams.set("$format", "json");
+    const response = await fetchImpl(endpoint);
+    if (!response.ok) throw new Error(`BCB PTAX request failed: ${response.status}`);
+    const body = await response.json();
+    const values = Array.isArray(body.value) ? body.value : [];
+    if (values.length === 0) continue;
+    const latest = values.at(-1);
+    const buy = Number(latest.cotacaoCompra);
+    const sell = Number(latest.cotacaoVenda);
+    if (!Number.isFinite(buy) || !Number.isFinite(sell)) throw new Error("BCB PTAX response is missing USD/BRL rates");
+    return {
+      source: "Banco Central do Brasil PTAX",
+      requestedDate: date,
+      observedDate,
+      brlPerUsdBuy: buy,
+      brlPerUsdSell: sell,
+      brlPerUsdMid: Number(((buy + sell) / 2).toFixed(6)),
+    };
+  }
+  throw new Error(`No BCB PTAX USD/BRL quote found within ${maxLookbackDays} days of ${date}`);
+}
+
+export function brlToUsd(brl, quote) {
+  const amount = Number(brl);
+  if (!Number.isFinite(amount)) throw new Error(`Invalid BRL amount: ${brl}`);
+  const rate = Number(quote.brlPerUsdSell);
+  if (!(rate > 0)) throw new Error("Invalid PTAX sell rate");
+  return amount / rate;
+}

--- a/services/pricing-intelligence/src/ical.js
+++ b/services/pricing-intelligence/src/ical.js
@@ -1,0 +1,81 @@
+import { createHash } from "node:crypto";
+
+function unfoldLines(text) {
+  const physical = String(text).replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n");
+  const logical = [];
+  for (const line of physical) {
+    if ((line.startsWith(" ") || line.startsWith("\t")) && logical.length > 0) {
+      logical[logical.length - 1] += line.slice(1);
+    } else {
+      logical.push(line);
+    }
+  }
+  return logical;
+}
+
+function propertyValue(line, name) {
+  const colon = line.indexOf(":");
+  if (colon < 0) return null;
+  const lhs = line.slice(0, colon).split(";", 1)[0].toUpperCase();
+  return lhs === name.toUpperCase() ? line.slice(colon + 1) : null;
+}
+
+function parseIcsDate(value) {
+  if (!/^\d{8}$/.test(value ?? "")) throw new Error(`Invalid iCalendar date: ${value}`);
+  return `${value.slice(0, 4)}-${value.slice(4, 6)}-${value.slice(6, 8)}`;
+}
+
+function eventKind(source, summary) {
+  const normalized = String(summary ?? "").trim().toLowerCase();
+  if (source === "airbnb") return normalized === "reserved" ? "reservation" : "blocked";
+  if (source === "vrbo") return normalized.startsWith("reserved") ? "reservation" : "blocked";
+  return normalized.startsWith("reserved") ? "reservation" : "blocked";
+}
+
+function eventHash(source, uid, start, endExclusive, kind) {
+  return createHash("sha256")
+    .update([source, uid ?? "", start, endExclusive, kind].join("\n"))
+    .digest("hex");
+}
+
+/**
+ * Parse a provider iCalendar without retaining descriptions, phone digits,
+ * reservation URLs, guest names, or raw summary text.
+ */
+export function parseProviderCalendar(text, { source }) {
+  if (!source) throw new Error("source is required");
+  const events = [];
+  let current = null;
+
+  for (const line of unfoldLines(text)) {
+    if (line === "BEGIN:VEVENT") {
+      current = {};
+      continue;
+    }
+    if (line === "END:VEVENT") {
+      if (!current?.start || !current?.endExclusive) throw new Error("VEVENT is missing DTSTART or DTEND");
+      const kind = eventKind(source, current.summary);
+      events.push({
+        source,
+        start: current.start,
+        endExclusive: current.endExclusive,
+        kind,
+        sourceEventHash: eventHash(source, current.uid, current.start, current.endExclusive, kind),
+      });
+      current = null;
+      continue;
+    }
+    if (!current) continue;
+
+    const start = propertyValue(line, "DTSTART");
+    const end = propertyValue(line, "DTEND");
+    const summary = propertyValue(line, "SUMMARY");
+    const uid = propertyValue(line, "UID");
+    if (start !== null) current.start = parseIcsDate(start);
+    if (end !== null) current.endExclusive = parseIcsDate(end);
+    if (summary !== null) current.summary = summary;
+    if (uid !== null) current.uid = uid;
+  }
+
+  return { source, events };
+}

--- a/services/pricing-intelligence/src/index.js
+++ b/services/pricing-intelligence/src/index.js
@@ -1,0 +1,8 @@
+import "./functions/daily-refresh.js";
+
+export { parseProviderCalendar } from "./ical.js";
+export { buildAvailabilitySnapshot, summarizeReservationIntervals } from "./availability.js";
+export { sanitizeAirbnbEarningsCsv } from "./airbnb-earnings.js";
+export { buildComparableSet, buildMarketCalendarSignals, comparableConfigFromCasa } from "./inside-airbnb.js";
+export { buildShadowRecommendation } from "./shadow-pricing.js";
+export { fetchPtaxUsdBrl, brlToUsd } from "./fx.js";

--- a/services/pricing-intelligence/src/index.js
+++ b/services/pricing-intelligence/src/index.js
@@ -1,8 +1,7 @@
-import "./functions/daily-refresh.js";
-
 export { parseProviderCalendar } from "./ical.js";
 export { buildAvailabilitySnapshot, summarizeReservationIntervals } from "./availability.js";
 export { sanitizeAirbnbEarningsCsv } from "./airbnb-earnings.js";
 export { buildComparableSet, buildMarketCalendarSignals, comparableConfigFromCasa } from "./inside-airbnb.js";
 export { buildShadowRecommendation } from "./shadow-pricing.js";
+export { buildIntelligenceSnapshot } from "./intelligence-snapshot.js";
 export { fetchPtaxUsdBrl, brlToUsd } from "./fx.js";

--- a/services/pricing-intelligence/src/inside-airbnb.js
+++ b/services/pricing-intelligence/src/inside-airbnb.js
@@ -1,0 +1,128 @@
+import { numberOrNull } from "./csv.js";
+
+function value(row, ...names) {
+  for (const name of names) if (row[name] !== undefined && row[name] !== "") return row[name];
+  return null;
+}
+
+function numeric(row, ...names) {
+  return numberOrNull(value(row, ...names));
+}
+
+function weightedQuantile(items, q) {
+  if (items.length === 0) return null;
+  const sorted = [...items].sort((a, b) => a.value - b.value);
+  const total = sorted.reduce((sum, item) => sum + item.weight, 0);
+  if (!(total > 0)) return null;
+  const threshold = total * q;
+  let cumulative = 0;
+  for (const item of sorted) {
+    cumulative += item.weight;
+    if (cumulative >= threshold) return item.value;
+  }
+  return sorted.at(-1).value;
+}
+
+function similarityWeight(row, config) {
+  const neighborhood = value(row, "neighbourhood_cleansed", "neighborhood");
+  const neighborhoodWeight = Number(config.neighborhoodWeights[neighborhood] ?? 0);
+  if (!(neighborhoodWeight > 0)) return 0;
+
+  const bedrooms = numeric(row, "bedrooms");
+  const bathrooms = numeric(row, "bathrooms");
+  const accommodates = numeric(row, "accommodates");
+  if (bedrooms === null || accommodates === null) return 0;
+
+  let weight = neighborhoodWeight;
+  weight *= Math.exp(-0.35 * Math.abs(bedrooms - config.target.bedrooms));
+  weight *= Math.exp(-0.14 * Math.abs(accommodates - config.target.accommodates));
+  if (bathrooms !== null) weight *= Math.exp(-0.18 * Math.abs(bathrooms - config.target.bathrooms));
+
+  const propertyType = String(value(row, "property_type") ?? "").toLowerCase();
+  if (propertyType.includes("villa")) weight *= 1.15;
+  else if (propertyType.includes("house") || propertyType.includes("home")) weight *= 1.05;
+  return weight;
+}
+
+export function buildComparableSet(listings, config) {
+  const rules = config.comparable;
+  return listings.flatMap((row) => {
+    const neighborhood = value(row, "neighbourhood_cleansed", "neighborhood");
+    const roomType = value(row, "room_type");
+    const bedrooms = numeric(row, "bedrooms");
+    const bathrooms = numeric(row, "bathrooms");
+    const accommodates = numeric(row, "accommodates");
+    if (!(neighborhood in config.neighborhoodWeights)) return [];
+    if (rules.roomType && roomType !== rules.roomType) return [];
+    if (bedrooms === null || bedrooms < rules.minimumBedrooms || bedrooms > rules.maximumBedrooms) return [];
+    if (accommodates === null || accommodates < rules.minimumAccommodates || accommodates > rules.maximumAccommodates) return [];
+    if (bathrooms !== null && bathrooms < rules.minimumBathrooms) return [];
+    const weight = similarityWeight(row, config);
+    if (!(weight > 0)) return [];
+    return [{
+      listingId: String(value(row, "id", "listing_id")),
+      neighborhood,
+      weight,
+      bedrooms,
+      bathrooms,
+      accommodates,
+    }];
+  });
+}
+
+/**
+ * Convert Inside Airbnb daily calendar rows into a weighted market-compression
+ * series. `available=false` is explicitly treated as unavailable inventory,
+ * not proven occupancy, because Inside Airbnb cannot distinguish host blocks.
+ */
+export function buildMarketCalendarSignals(calendarRows, comparableSet) {
+  const weights = new Map(comparableSet.map((item) => [item.listingId, item.weight]));
+  const totalWeight = comparableSet.reduce((sum, item) => sum + item.weight, 0);
+  const weightSquares = comparableSet.reduce((sum, item) => sum + item.weight ** 2, 0);
+  const effectiveSampleSize = weightSquares > 0 ? (totalWeight ** 2) / weightSquares : 0;
+  const byDate = new Map();
+
+  for (const row of calendarRows) {
+    const listingId = String(value(row, "listing_id", "id"));
+    const weight = weights.get(listingId);
+    if (!weight) continue;
+    const date = value(row, "date");
+    if (!date) continue;
+    const available = String(value(row, "available") ?? "").toLowerCase();
+    const isAvailable = available === "t" || available === "true" || available === "1";
+    const minimumNights = numeric(row, "minimum_nights");
+    const bucket = byDate.get(date) ?? { availableWeight: 0, availableCount: 0, minStay: [] };
+    if (isAvailable) {
+      bucket.availableWeight += weight;
+      bucket.availableCount += 1;
+      if (minimumNights !== null) bucket.minStay.push({ value: minimumNights, weight });
+    }
+    byDate.set(date, bucket);
+  }
+
+  return Object.fromEntries([...byDate.entries()].sort(([a], [b]) => a.localeCompare(b)).map(([date, bucket]) => {
+    const availabilityRate = totalWeight > 0 ? bucket.availableWeight / totalWeight : null;
+    return [date, {
+      comparableCount: comparableSet.length,
+      availableComparableCount: bucket.availableCount,
+      effectiveSampleSize: Number(effectiveSampleSize.toFixed(2)),
+      weightedAvailabilityRate: availabilityRate === null ? null : Number(availabilityRate.toFixed(6)),
+      marketCompressionIndex: availabilityRate === null ? null : Number((1 - availabilityRate).toFixed(6)),
+      marketMedianMinimumStay: weightedQuantile(bucket.minStay, 0.5),
+      marketP75MinimumStay: weightedQuantile(bucket.minStay, 0.75),
+      unavailableMeans: "booked-or-host-blocked",
+    }];
+  }));
+}
+
+export function comparableConfigFromCasa(config) {
+  return {
+    neighborhoodWeights: config.market.neighborhoodWeights,
+    comparable: config.market.comparable,
+    target: {
+      bedrooms: config.listing.bedrooms,
+      bathrooms: config.listing.bathrooms,
+      accommodates: config.listing.accommodates,
+    },
+  };
+}

--- a/services/pricing-intelligence/src/intelligence-snapshot.js
+++ b/services/pricing-intelligence/src/intelligence-snapshot.js
@@ -1,0 +1,71 @@
+import { createHash } from "node:crypto";
+import { buildShadowRecommendation } from "./shadow-pricing.js";
+
+function canonical(value) {
+  if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonical(value[key])}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function hash(value) {
+  return createHash("sha256").update(canonical(value)).digest("hex");
+}
+
+/**
+ * Build an immutable shadow intelligence snapshot. Policy anchors remain the
+ * authoritative starting prices; this service never mutates the rule set and
+ * never publishes its recommendations.
+ */
+export function buildIntelligenceSnapshot({
+  asOf,
+  marketSnapshot,
+  availabilitySnapshot = null,
+  policyAnchorsByDate,
+  bookingPaceByDate = {},
+  searchDemandByDate = {},
+  eventDemandByDate = {},
+  shadowConfig = {},
+}) {
+  if (!asOf) throw new Error("asOf is required");
+  if (!marketSnapshot?.dates) throw new Error("marketSnapshot.dates is required");
+  if (!policyAnchorsByDate || typeof policyAnchorsByDate !== "object") throw new Error("policyAnchorsByDate is required");
+
+  const recommendations = {};
+  for (const [date, anchor] of Object.entries(policyAnchorsByDate).sort(([a], [b]) => a.localeCompare(b))) {
+    const marketSignal = marketSnapshot.dates[date] ?? {};
+    recommendations[date] = buildShadowRecommendation({
+      date,
+      asOf,
+      policyAnchorUsd: anchor,
+      marketSignal,
+      bookingPaceIndex: bookingPaceByDate[date] ?? null,
+      searchDemandIndex: searchDemandByDate[date] ?? null,
+      eventDemandIndex: eventDemandByDate[date] ?? null,
+      config: shadowConfig,
+    });
+  }
+
+  const inputs = {
+    marketSnapshotHash: hash(marketSnapshot),
+    availabilitySnapshotHash: availabilitySnapshot ? hash(availabilitySnapshot) : null,
+    policyAnchorsHash: hash(policyAnchorsByDate),
+  };
+  const snapshotBody = {
+    schema: "pmc.pricing-intelligence-snapshot/v1",
+    asOf,
+    model: {
+      id: "pmc-shadow-heuristic",
+      version: 1,
+      mode: "shadow",
+      publishingEnabled: false,
+    },
+    inputs,
+    recommendations,
+  };
+  return {
+    id: `casa-intelligence-${hash(snapshotBody).slice(0, 16)}`,
+    ...snapshotBody,
+  };
+}

--- a/services/pricing-intelligence/src/secrets.js
+++ b/services/pricing-intelligence/src/secrets.js
@@ -1,0 +1,24 @@
+import { DefaultAzureCredential } from "@azure/identity";
+import { SecretClient } from "@azure/keyvault-secrets";
+
+function credential() {
+  return new DefaultAzureCredential({
+    managedIdentityClientId: process.env.AZURE_CLIENT_ID || undefined,
+  });
+}
+
+export async function getSecretValue(name) {
+  const vaultUrl = process.env.KEY_VAULT_URL;
+  if (!vaultUrl) throw new Error("KEY_VAULT_URL is required");
+  const client = new SecretClient(vaultUrl, credential());
+  const secret = await client.getSecret(name);
+  if (!secret.value) throw new Error(`Key Vault secret ${name} has no value`);
+  return secret.value;
+}
+
+export async function getProviderCalendarUrls() {
+  // Local development may supply the URLs directly. Production should use Key Vault.
+  const airbnb = process.env.AIRBNB_ICAL_URL || await getSecretValue(process.env.AIRBNB_ICAL_SECRET_NAME ?? "airbnb-ical-url");
+  const vrbo = process.env.VRBO_ICAL_URL || await getSecretValue(process.env.VRBO_ICAL_SECRET_NAME ?? "vrbo-ical-url");
+  return { airbnb, vrbo };
+}

--- a/services/pricing-intelligence/src/shadow-pricing.js
+++ b/services/pricing-intelligence/src/shadow-pricing.js
@@ -1,0 +1,109 @@
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function parseMoney(value) {
+  const number = Number(value);
+  if (!Number.isFinite(number) || number < 0) throw new Error(`Invalid money value: ${value}`);
+  return number;
+}
+
+function roundIncrement(value, increment) {
+  return Math.round(value / increment) * increment;
+}
+
+function daysBetween(asOf, date) {
+  const from = Date.parse(`${asOf.slice(0, 10)}T00:00:00Z`);
+  const to = Date.parse(`${date}T00:00:00Z`);
+  if (!Number.isFinite(from) || !Number.isFinite(to)) throw new Error("Invalid date input");
+  return Math.round((to - from) / 86400000);
+}
+
+function leadTimePercent(days) {
+  if (days <= 7) return -12;
+  if (days <= 21) return -7;
+  if (days <= 45) return -3;
+  if (days >= 365) return 12;
+  if (days >= 180) return 7;
+  return 0;
+}
+
+/**
+ * Transparent v1 shadow model. It deliberately does not publish prices and is
+ * intended to generate auditable recommendations while enough point-in-time
+ * history is collected for later statistical/ML models.
+ */
+export function buildShadowRecommendation({
+  date,
+  asOf,
+  policyAnchorUsd,
+  marketSignal = {},
+  bookingPaceIndex = null,
+  searchDemandIndex = null,
+  eventDemandIndex = null,
+  config = {},
+}) {
+  const anchor = parseMoney(policyAnchorUsd);
+  const increment = parseMoney(config.roundingIncrementUsd ?? "5.00");
+  const maxIncrease = Number(config.maximumShadowIncreasePercent ?? 35);
+  const maxDecrease = Number(config.maximumShadowDecreasePercent ?? 25);
+  const daysToArrival = daysBetween(asOf, date);
+
+  const factors = [];
+  const compression = Number(marketSignal.marketCompressionIndex);
+  const baselineCompression = Number(marketSignal.baselineCompressionIndex ?? 0.5);
+  if (Number.isFinite(compression) && Number.isFinite(baselineCompression)) {
+    factors.push({
+      key: "marketCompression",
+      percent: clamp((compression - baselineCompression) * 80, -15, 30),
+      evidence: { compression, baselineCompression },
+    });
+  }
+
+  const marketAvailability = Number(marketSignal.weightedAvailabilityRate);
+  if (Number.isFinite(marketAvailability)) {
+    const percent = marketAvailability < 0.35 ? 5 : marketAvailability > 0.70 ? -5 : 0;
+    factors.push({ key: "marketAvailability", percent, evidence: { marketAvailability } });
+  }
+
+  factors.push({ key: "leadTime", percent: leadTimePercent(daysToArrival), evidence: { daysToArrival } });
+
+  if (Number.isFinite(Number(bookingPaceIndex))) {
+    const index = Number(bookingPaceIndex);
+    factors.push({ key: "bookingPace", percent: clamp((index - 1) * 15, -10, 12), evidence: { index } });
+  }
+  if (Number.isFinite(Number(searchDemandIndex))) {
+    const index = Number(searchDemandIndex);
+    factors.push({ key: "searchDemand", percent: clamp((index - 1) * 12, -8, 12), evidence: { index } });
+  }
+  if (Number.isFinite(Number(eventDemandIndex))) {
+    const index = Number(eventDemandIndex);
+    factors.push({ key: "eventDemand", percent: clamp((index - 1) * 15, 0, 15), evidence: { index } });
+  }
+
+  const rawPercent = factors.reduce((sum, factor) => sum + factor.percent, 0);
+  const boundedPercent = clamp(rawPercent, -maxDecrease, maxIncrease);
+  const unrounded = anchor * (1 + boundedPercent / 100);
+  const recommended = roundIncrement(unrounded, increment);
+
+  let confidence = 0.25;
+  if (Number.isFinite(compression)) confidence += 0.20;
+  if (Number(marketSignal.effectiveSampleSize) >= 30) confidence += 0.15;
+  if (Number.isFinite(Number(bookingPaceIndex))) confidence += 0.10;
+  if (Number.isFinite(Number(searchDemandIndex))) confidence += 0.10;
+  if (Number.isFinite(Number(eventDemandIndex))) confidence += 0.05;
+  confidence = Math.min(confidence, 0.85);
+
+  return {
+    date,
+    mode: "shadow",
+    publish: false,
+    policyAnchorUsd: anchor.toFixed(2),
+    rawAdjustmentPercent: Number(rawPercent.toFixed(4)),
+    boundedAdjustmentPercent: Number(boundedPercent.toFixed(4)),
+    unroundedShadowUsd: unrounded.toFixed(2),
+    recommendedNightlyUsd: recommended.toFixed(2),
+    confidence: Number(confidence.toFixed(2)),
+    factors: factors.map((factor) => ({ ...factor, percent: Number(factor.percent.toFixed(4)) })),
+  };
+}

--- a/services/pricing-intelligence/src/storage.js
+++ b/services/pricing-intelligence/src/storage.js
@@ -1,0 +1,31 @@
+import { DefaultAzureCredential } from "@azure/identity";
+import { BlobServiceClient } from "@azure/storage-blob";
+
+function client(accountUrl) {
+  if (!accountUrl) throw new Error("PRICING_STORAGE_ACCOUNT_URL is required");
+  return new BlobServiceClient(accountUrl, new DefaultAzureCredential({
+    managedIdentityClientId: process.env.AZURE_CLIENT_ID || undefined,
+  }));
+}
+
+export async function writeImmutableJson({ accountUrl, container, blobName, value }) {
+  const containerClient = client(accountUrl).getContainerClient(container);
+  const blob = containerClient.getBlockBlobClient(blobName);
+  const body = `${JSON.stringify(value, null, 2)}\n`;
+  await blob.upload(body, Buffer.byteLength(body), {
+    blobHTTPHeaders: { blobContentType: "application/json; charset=utf-8" },
+    conditions: { ifNoneMatch: "*" },
+  });
+  return blob.url;
+}
+
+export async function writeLatestJson({ accountUrl, container, blobName, value }) {
+  const containerClient = client(accountUrl).getContainerClient(container);
+  const blob = containerClient.getBlockBlobClient(blobName);
+  const body = `${JSON.stringify(value, null, 2)}\n`;
+  await blob.upload(body, Buffer.byteLength(body), {
+    overwrite: true,
+    blobHTTPHeaders: { blobContentType: "application/json; charset=utf-8" },
+  });
+  return blob.url;
+}

--- a/services/pricing-intelligence/test/intelligence.test.js
+++ b/services/pricing-intelligence/test/intelligence.test.js
@@ -4,6 +4,7 @@ import { parseProviderCalendar } from "../src/ical.js";
 import { buildAvailabilitySnapshot } from "../src/availability.js";
 import { sanitizeAirbnbEarningsCsv } from "../src/airbnb-earnings.js";
 import { buildShadowRecommendation } from "../src/shadow-pricing.js";
+import { buildIntelligenceSnapshot } from "../src/intelligence-snapshot.js";
 
 const airbnb = `BEGIN:VCALENDAR\nBEGIN:VEVENT\nDTSTART;VALUE=DATE:20270101\nDTEND;VALUE=DATE:20270105\nSUMMARY:Reserved\nUID:a\nDESCRIPTION:Phone Number: 1234\nEND:VEVENT\nEND:VCALENDAR`;
 const vrbo = `BEGIN:VCALENDAR\nBEGIN:VEVENT\nDTSTART;VALUE=DATE:20270101\nDTEND;VALUE=DATE:20270105\nSUMMARY:Blocked\nUID:b\nEND:VEVENT\nEND:VCALENDAR`;
@@ -47,4 +48,27 @@ test("shadow pricing never publishes", () => {
   assert.equal(result.mode, "shadow");
   assert.equal(result.publish, false);
   assert.ok(Number(result.recommendedNightlyUsd) > 800);
+});
+
+test("intelligence snapshot is deterministic and shadow-only", () => {
+  const input = {
+    asOf: "2026-08-23T00:00:00Z",
+    marketSnapshot: {
+      schema: "pmc.market-intelligence-snapshot/v1",
+      dates: {
+        "2027-02-06": {
+          marketCompressionIndex: 0.65,
+          weightedAvailabilityRate: 0.35,
+          effectiveSampleSize: 100,
+        },
+      },
+    },
+    policyAnchorsByDate: { "2027-02-06": "800.00" },
+    eventDemandByDate: { "2027-02-06": 1.2 },
+  };
+  const first = buildIntelligenceSnapshot(input);
+  const second = buildIntelligenceSnapshot(input);
+  assert.equal(first.id, second.id);
+  assert.equal(first.model.publishingEnabled, false);
+  assert.equal(first.recommendations["2027-02-06"].publish, false);
 });

--- a/services/pricing-intelligence/test/intelligence.test.js
+++ b/services/pricing-intelligence/test/intelligence.test.js
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { parseProviderCalendar } from "../src/ical.js";
+import { buildAvailabilitySnapshot } from "../src/availability.js";
+import { sanitizeAirbnbEarningsCsv } from "../src/airbnb-earnings.js";
+import { buildShadowRecommendation } from "../src/shadow-pricing.js";
+
+const airbnb = `BEGIN:VCALENDAR\nBEGIN:VEVENT\nDTSTART;VALUE=DATE:20270101\nDTEND;VALUE=DATE:20270105\nSUMMARY:Reserved\nUID:a\nDESCRIPTION:Phone Number: 1234\nEND:VEVENT\nEND:VCALENDAR`;
+const vrbo = `BEGIN:VCALENDAR\nBEGIN:VEVENT\nDTSTART;VALUE=DATE:20270101\nDTEND;VALUE=DATE:20270105\nSUMMARY:Blocked\nUID:b\nEND:VEVENT\nEND:VCALENDAR`;
+
+test("calendar parser strips provider PII", () => {
+  const parsed = parseProviderCalendar(airbnb, { source: "airbnb" });
+  assert.equal(parsed.events[0].kind, "reservation");
+  assert.deepEqual(Object.keys(parsed.events[0]).sort(), ["endExclusive", "kind", "source", "sourceEventHash", "start"].sort());
+  assert.equal(JSON.stringify(parsed).includes("1234"), false);
+});
+
+test("mirrored block does not double-count a reservation", () => {
+  const snapshot = buildAvailabilitySnapshot({
+    calendars: [parseProviderCalendar(airbnb, { source: "airbnb" }), parseProviderCalendar(vrbo, { source: "vrbo" })],
+    from: "2027-01-01",
+    through: "2027-01-05",
+    asOf: "2026-08-23T00:00:00Z",
+  });
+  assert.equal(snapshot.counts.reserved, 4);
+  assert.equal(snapshot.counts.blocked, 0);
+  assert.equal(snapshot.counts.available, 1);
+});
+
+test("earnings sanitizer removes identities", () => {
+  const csv = "Type,Booking date,Start date,End date,Nights,Guest,Confirmation code,Currency,Amount,Service fee,Cleaning fee,Gross earnings,Airbnb remitted tax\nReservation,08/01/2026,08/06/2026,08/11/2026,5,Alice,SECRET,BRL,100,4,0,104,0\n";
+  const result = sanitizeAirbnbEarningsCsv(csv);
+  assert.equal(result.reservations.length, 1);
+  assert.equal(JSON.stringify(result).includes("Alice"), false);
+  assert.equal(JSON.stringify(result).includes("SECRET"), false);
+  assert.equal(result.summaryByCurrency.BRL.nights, 5);
+});
+
+test("shadow pricing never publishes", () => {
+  const result = buildShadowRecommendation({
+    date: "2027-02-06",
+    asOf: "2026-08-23T00:00:00Z",
+    policyAnchorUsd: "800.00",
+    marketSignal: { marketCompressionIndex: 0.65, weightedAvailabilityRate: 0.35, effectiveSampleSize: 100 },
+    eventDemandIndex: 1.2,
+  });
+  assert.equal(result.mode, "shadow");
+  assert.equal(result.publish, false);
+  assert.ok(Number(result.recommendedNightlyUsd) > 800);
+});


### PR DESCRIPTION
## Summary

Adds a separate read-only pricing intelligence service for Casa de Pedra. It is intentionally outside `@pmc/price-engine` and does not publish prices.

### Data inputs
- Daily Airbnb + Vrbo iCalendar ingestion through Key Vault secrets
- Privacy-preserving Airbnb earnings history
- Streaming Inside Airbnb Rio ETL
- Banco Central do Brasil PTAX USD/BRL normalization
- Owner-provided Airbnb performance metrics stored as `last_month` without inventing exact dates

### Intelligence
- Weighted comparable set across Copacabana (1.00), Ipanema (0.85), and Leblon (0.75), with additional property-similarity weighting
- Market availability/compression and minimum-stay signals
- Immutable availability and intelligence snapshots
- Transparent shadow-price recommendation model with factor attribution and confidence
- Hard `publish: false` / `publishingEnabled: false`

### Safety/privacy
- Raw provider calendars are never persisted
- Guest names, phone digits, reservation URLs, confirmation/reference codes and payout details are discarded
- Calendar URLs stay in Azure Key Vault
- No production deployment workflow is added
- No direct-site search telemetry is added in this change

### Infrastructure
- Separate Azure Function module
- Private `pricing-intelligence` and `pricing-intelligence-raw` Blob containers
- Managed identity for Blob/Key Vault access
- Non-deploying CI validation only

### Known follow-ups
- Create/verify Google Search Console domain property and GA4 Web stream using the owner's Google account; repo documents the required setup but cannot create account properties itself.
- Add Search Console / GA4 collectors once the properties exist.
- Add direct-site search/quote telemetry later, per owner decision.
- Keep model in shadow mode while point-in-time history accumulates.
